### PR TITLE
CLI application, Argon2 and scrypt support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-htpasswd"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 description = "Simple file-based authentication in Axum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ readme = "README.md"
 argon2 = { version = "0.5.3", features = ["rand"] }
 axum = { version = "0.7" }
 base64 = "0.21"
-clap = { version = "4.5", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"], optional = true }
 http-body = "1.0"
 log = { version = "0.4", features = ["std"] }
 password-hash = { version = "0.5.0", features = ["getrandom"] }
-rpassword = "7.3.1"
+rpassword = { version = "7.3.1", optional = true }
 text_io = "0.1.12"
 tokio = { version = "1.33.0", features = ["fs", "io-std", "macros"] }
 tower-http = { version = "0.5", features = ["full"] }
@@ -27,3 +27,6 @@ tower-http = { version = "0.5", features = ["full"] }
 [dev-dependencies]
 tempfile = "3.9.0"
 simple_logger = { version = "4.3", features = ["stderr"] }
+
+[features]
+cli = ["clap", "rpassword"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,15 @@ keywords = ["http", "web", "authentication"]
 readme = "README.md"
 
 [dependencies]
+argon2 = { version = "0.5.3", features = ["rand"] }
 axum = { version = "0.7" }
 base64 = "0.21"
+clap = { version = "4.5", features = ["derive"] }
 http-body = "1.0"
 log = { version = "0.4", features = ["std"] }
+password-hash = { version = "0.5.0", features = ["getrandom"] }
+rpassword = "7.3.1"
+text_io = "0.1.12"
 tokio = { version = "1.33.0", features = ["fs", "io-std", "macros"] }
 tower-http = { version = "0.5", features = ["full"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ http-body = "1.0"
 log = { version = "0.4", features = ["std"] }
 password-hash = { version = "0.5.0", features = ["getrandom"] }
 rpassword = { version = "7.3.1", optional = true }
+scrypt = "0.11.0"
 text_io = "0.1.12"
 tokio = { version = "1.33.0", features = ["fs", "io-std", "macros"] }
 tower-http = { version = "0.5", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 Even the simplest web applications require the authentication of users for
 various usages. The goal of this package is to allow this in the simplest way
 possible that has been around since forever: Using a htpasswd file.
+
+`axum-htpasswd` supports files with password in plaintext (not recommended), or
+hashed using Argon2id (recommended), or scrypt.
+
+By enabling the feature `cli`, the built application will support generating
+htpasswd files.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "cli")]
+
 use axum_htpasswd::Encoding;
 use clap::Parser;
 use rpassword::prompt_password;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,13 +1,18 @@
 #![cfg(feature = "cli")]
 
-use axum_htpasswd::Encoding;
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use rpassword::prompt_password;
 use std::{
     fmt,
     fs::{File, OpenOptions},
     io::{BufWriter, Error, Write},
 };
+
+#[derive(Debug, Copy, Clone, ValueEnum)]
+pub enum Encoding {
+    PlainText,
+    Argon2,
+}
 
 #[derive(Debug, Clone)]
 struct HtpasswdError {
@@ -82,8 +87,7 @@ fn ask_for_password() -> Result<String, HtpasswdError> {
 fn encode_password(enc: Encoding, password: String) -> Result<String, HtpasswdError> {
     match enc {
         Encoding::PlainText => { return Ok(password) },
-        Encoding::MD5 => todo!(),
-        Encoding::ARGON => { return argon_encode(password)},
+        Encoding::Argon2 => { return argon_encode(password)},
     }
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,103 @@
+use axum_htpasswd::Encoding;
+use clap::Parser;
+use rpassword::prompt_password;
+use std::{
+    fmt,
+    fs::{File, OpenOptions},
+    io::{BufWriter, Error, Write},
+};
+
+#[derive(Debug, Clone)]
+struct HtpasswdError {
+    message: String,
+}
+
+impl HtpasswdError {
+    fn new(msg: &str) -> HtpasswdError {
+        HtpasswdError {
+            message: msg.to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for HtpasswdError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Error: {}", self.message)
+    }
+}
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(short, long)]
+    encoding: Encoding,
+
+    #[arg(short, long)]
+    file: String,
+
+    #[arg(short, long)]
+    username: String,
+}
+
+pub fn run() {
+    let args = Args::parse();
+    match ask_for_password()
+        .and_then(|p| { encode_password(args.encoding, p) })
+        .and_then(|password| {
+      OpenOptions::new().create(true).append(true).open(args.file)
+      .map_err(|_| HtpasswdError::new("Failed to open htpasswd file"))
+      .and_then(|f| {
+        write_entry(f, args.username, password)
+        .map_err(|_| HtpasswdError::new("Failed to write to htpasswd file"))
+      })
+    }) {
+      Ok(_) => {
+        println!("Done.")
+    }
+    Err(e) => {
+        println!("{}", e)
+    }
+
+    };
+}
+
+fn ask_for_password() -> Result<String, HtpasswdError> {
+    prompt_password("Enter password: ")
+        .map_err(|_| HtpasswdError::new("Failed to read password"))
+        .and_then(|first_entry| {
+            prompt_password("Confirm password: ")
+                .map_err(|_| HtpasswdError::new("Failed to read confirmation"))
+                .and_then(|second_entry| {
+                    if first_entry == second_entry {
+                        Ok(first_entry)
+                    } else {
+                        Err(HtpasswdError::new("Passwords do not match"))
+                    }
+                })
+        })
+}
+
+fn encode_password(enc: Encoding, password: String) -> Result<String, HtpasswdError> {
+    match enc {
+        Encoding::PlainText => { return Ok(password) },
+        Encoding::MD5 => todo!(),
+        Encoding::ARGON => { return argon_encode(password)},
+    }
+}
+
+fn argon_encode(password: String) -> Result<String, HtpasswdError> {
+    use argon2::{password_hash::{rand_core::OsRng, PasswordHasher, SaltString},Argon2};
+
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::default();
+
+    match argon2.hash_password(password.as_bytes(), &salt) {
+        Ok(password_hash) => { return Ok(password_hash.to_string()); },
+        Err(error) => { return Err(HtpasswdError::new(error.to_string().as_str())) }
+    }
+}
+
+fn write_entry(f: File, username: String, password: String) -> Result<(), Error> {
+    let mut buf_writer = BufWriter::new(f);
+    writeln!(buf_writer, "{username}:{password}")
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 use axum::http::{header, Request, Response, StatusCode};
 use base64::{engine::general_purpose, Engine as _};
+use clap::ValueEnum;
 use http_body::Body;
 use log::{debug, error};
 use std::marker::PhantomData;
@@ -15,7 +16,7 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tower_http::validate_request::ValidateRequest;
 
-#[derive(Debug, Copy, Clone)]
+#[derive(ValueEnum, Debug, Copy, Clone)]
 pub enum Encoding {
     PlainText,
     MD5,   // not implemented yet!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 
 use axum::http::{header, Request, Response, StatusCode};
 use base64::{engine::general_purpose, Engine as _};
+#[cfg(feature = "cli")]
 use clap::ValueEnum;
 use http_body::Body;
 use log::{debug, error};
@@ -16,7 +17,8 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tower_http::validate_request::ValidateRequest;
 
-#[derive(ValueEnum, Debug, Copy, Clone)]
+#[cfg_attr(feature = "cli", derive(ValueEnum))]
+#[derive(Debug, Copy, Clone)]
 pub enum Encoding {
     PlainText,
     MD5,   // not implemented yet!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@ use argon2::Argon2;
 use password_hash::{PasswordHash, PasswordVerifier};
 use axum::http::{header, Request, Response, StatusCode};
 use base64::{engine::general_purpose, Engine as _};
-#[cfg(feature = "cli")]
-use clap::ValueEnum;
 use http_body::Body;
 use log::{debug, error, info};
 use std::collections::HashMap;
@@ -19,14 +17,6 @@ use std::str;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tower_http::validate_request::ValidateRequest;
-
-#[cfg_attr(feature = "cli", derive(ValueEnum))]
-#[derive(Debug, Copy, Clone)]
-pub enum Encoding {
-    PlainText,
-    MD5,   // not implemented yet!
-    ARGON, // not implemented yet!
-}
 
 /// File-based authentication provider backed by a plaintext file.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl<ResBody> FileAuth<ResBody> {
                     if let Some(pos) = credentials.find(':') {
                         if let Some(saved_password) = self.known_users.get(&credentials[0..pos - 1])
                         {
-                            if check_password(&*saved_password, &credentials[pos + 1..]) {
+                            if check_password(saved_password, &credentials[pos + 1..]) {
                                 info!(
                                     "Correct password supplied for user {}",
                                     &credentials[0..pos - 1]
@@ -179,7 +179,7 @@ impl<ResBody> Clone for FileAuth<ResBody> {
 }
 
 fn check_password(saved: &str, passed: &str) -> bool {
-    match PasswordHash::new(&saved) {
+    match PasswordHash::new(saved) {
         Ok(pw_hash) => {
             // The PHC string could be parsed, we can attempt to verify the password hashes
             let algs: &[&dyn PasswordVerifier] = &[&Argon2::default(), &Scrypt];
@@ -195,11 +195,7 @@ fn check_password(saved: &str, passed: &str) -> bool {
         Err(_) => {
             // The PHC string could not be parsed. Let's assume it's a plaintext password and
             // try to verify it.
-            if saved == passed {
-                true
-            } else {
-                false
-            }
+            saved == passed
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,5 @@
+mod cli;
+
+fn main() {
+    cli::run();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 mod cli;
 
 fn main() {
-    #[cfg(feature="cli")]
+    #[cfg(feature = "cli")]
     cli::run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 
 fn main() {
+    #[cfg(feature="cli")]
     cli::run();
 }


### PR DESCRIPTION
* Add a CLI application to easily create htpasswd files
* Add support for Argon2-hashed passwords (both for generating and verifying)
* Add support for scrypt-hashed passwords (both for generating and verifying)